### PR TITLE
Remove dead code pertaining to the ClientSessionState nonce field abuse

### DIFF
--- a/handshake_client_tls13.go
+++ b/handshake_client_tls13.go
@@ -10,7 +10,6 @@ import (
 	"crypto"
 	"crypto/hmac"
 	"crypto/rsa"
-	"encoding/binary"
 	"errors"
 	"hash"
 	"sync/atomic"
@@ -688,10 +687,6 @@ func (c *Conn) handleNewSessionTicket(msg *newSessionTicketMsgTLS13) error {
 	// However, at the same time, the qtls.ClientSessionTicket needs to be equal to
 	// the tls.ClientSessionTicket, so we can't just add a new field to the struct.
 	// We therefore abuse the nonce field (which is a byte slice)
-	nonceWithEarlyData := make([]byte, len(msg.nonce)+4)
-	binary.BigEndian.PutUint32(nonceWithEarlyData, msg.maxEarlyData)
-	copy(nonceWithEarlyData[4:], msg.nonce)
-
 	var appData []byte
 	if c.extraConfig != nil && c.extraConfig.GetAppDataForSessionState != nil {
 		appData = c.extraConfig.GetAppDataForSessionState()


### PR DESCRIPTION
Hi,

I've recently been using qtls to experiment with SessionTickets. In the course of this, I noticed that there is some dead code related to the storing of the max_early_data_size in the nonce field of the ClientSessionTicket (37d07723 introduced some changes that made this code obsolete). I thought it might be a good idea to remove this before somebody else gets confused.